### PR TITLE
The ubuntu DAILY image doesn't exist anymore.

### DIFF
--- a/templates/template.json
+++ b/templates/template.json
@@ -50,7 +50,7 @@
     },
     "imageSku": {
       "type": "string",
-      "defaultValue": "16.04.0-DAILY-LTS",
+      "defaultValue": "16.04.0-LTS",
       "metadata": {
         "description": "Name of the image sku"
       }


### PR DESCRIPTION
I get this error message with the original version:

"message": "The platform image 'canonical:ubuntuserver:16.04.0-DAILY-LTS:latest' is not available. Verify that all fields in the storage profile are correct."

Everything works with the non DAILY image.

